### PR TITLE
Add ISCC to multicodecs table

### DIFF
--- a/table.csv
+++ b/table.csv
@@ -124,6 +124,7 @@ http,                           multiaddr,      0x01e0,         draft,
 swhid-1-snp,                    ipld,           0x01f0,         draft,     SoftWare Heritage persistent IDentifier version 1 snapshot
 json,                           ipld,           0x0200,         permanent, JSON (UTF-8-encoded)
 messagepack,                    serialization,  0x0201,         draft,     MessagePack
+car,                            serialization,  0x0202,         draft,     Content Addressable aRchive (CAR)
 libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2p peer record type
 libp2p-relay-rsvp,              libp2p,         0x0302,         permanent, libp2p relay reservation voucher
 car-index-sorted,               serialization,  0x0400,         draft,     CARv2 IndexSorted index format

--- a/table.csv
+++ b/table.csv
@@ -129,6 +129,8 @@ libp2p-peer-record,             libp2p,         0x0301,         permanent, libp2
 libp2p-relay-rsvp,              libp2p,         0x0302,         permanent, libp2p relay reservation voucher
 car-index-sorted,               serialization,  0x0400,         draft,     CARv2 IndexSorted index format
 car-multihash-index-sorted,     serialization,  0x0401,         draft,     CARv2 MultihashIndexSorted index format
+transport-bitswap,              transport,      0x0900,         draft,     Bitswap datatransfer
+transport-graphsync-filecoinv1, transport,      0x0910,         draft,     Filecoin graphsync datatransfer
 sha2-256-trunc254-padded,       multihash,      0x1012,         permanent, SHA2-256 with the two most significant bits from the last byte zeroed (as via a mask with 0b00111111) - used for proving trees as in Filecoin
 sha2-224,                       multihash,      0x1013,         permanent, aka SHA-224; as specified by FIPS 180-4.
 sha2-512-224,                   multihash,      0x1014,         permanent, aka SHA-512/224; as specified by FIPS 180-4.

--- a/table.csv
+++ b/table.csv
@@ -488,3 +488,4 @@ holochain-sig-v1,               holochain,      0xa37124,       draft,     Holoc
 skynet-ns,                      namespace,      0xb19910,       draft,     Skynet Namespace
 arweave-ns,                     namespace,      0xb29910,       draft,     Arweave Namespace
 subspace-ns,                    namespace,      0xb39910,       draft,     Subspace Network Namespace
+kumandra-ns,                    namespace,      0xb49910,       draft,     Kumandra Network Namespace

--- a/table.csv
+++ b/table.csv
@@ -117,6 +117,7 @@ garlic32,                       multiaddr,      0x01bf,         draft,     I2P b
 tls,                            multiaddr,      0x01c0,         draft,
 noise,                          multiaddr,      0x01c6,         draft,
 quic,                           multiaddr,      0x01cc,         permanent,
+webtransport,                   multiaddr,      0x01d1,         draft,
 ws,                             multiaddr,      0x01dd,         permanent,
 wss,                            multiaddr,      0x01de,         permanent,
 p2p-websocket-star,             multiaddr,      0x01df,         permanent,

--- a/table.csv
+++ b/table.csv
@@ -471,6 +471,7 @@ skein1024-1016,                 multihash,      0xb3df,         draft,
 skein1024-1024,                 multihash,      0xb3e0,         draft,
 poseidon-bls12_381-a2-fc1,      multihash,      0xb401,         permanent, Poseidon using BLS12-381 and arity of 2 with Filecoin parameters
 poseidon-bls12_381-a2-fc1-sc,   multihash,      0xb402,         draft,     Poseidon using BLS12-381 and arity of 2 with Filecoin parameters - high-security variant
+iscc,                           softhash,       0xcc01,         draft,     ISCC (International Standard Content Code) - similarity preserving hash
 zeroxcert-imprint-256,          zeroxcert,      0xce11,         draft,     0xcert Asset Imprint (root hash)
 fil-commitment-unsealed,        filecoin,       0xf101,         permanent, Filecoin piece or sector data commitment merkle node/root (CommP & CommD)
 fil-commitment-sealed,          filecoin,       0xf102,         permanent, Filecoin sector data commitment merkle node/root - sealed and replicated (CommR)


### PR DESCRIPTION
The ISCC is similarity preserving identifier for digital content. An ISCC is derived algorithmically from the digital content itself, just like cryptographic hashes. However, instead of using a single cryptographic hash function to identify data only, the ISCC uses a variety of algorithms to create a composite identifier that exhibits similarity-preserving properties (softhash). For an implementation of code `0xcc01` see: https://iscc-core.iscc.codes/#quick-start